### PR TITLE
Change pointer in .gitmodules to forked repo gz.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -72,10 +72,6 @@
 	path = src/lib/heatshrink/heatshrink
 	url = https://github.com/PX4/heatshrink.git
 	branch = px4
-[submodule "Tools/simulation/gz"]
-	path = Tools/simulation/gz
-	url = https://github.com/PX4/PX4-gazebo-models.git
-	branch = main
 [submodule "boards/modalai/voxl2/libfc-sensor-api"]
 	path = boards/modalai/voxl2/libfc-sensor-api
 	url = https://gitlab.com/voxl-public/voxl-sdk/core-libs/libfc-sensor-api.git
@@ -89,3 +85,6 @@
 [submodule "src/drivers/uavcan/libdronecan/libuavcan/dsdl_compiler/pydronecan"]
 	path = src/drivers/uavcan/libdronecan/libuavcan/dsdl_compiler/pydronecan
 	url = https://github.com/dronecan/pydronecan
+[submodule "Tools/simulation/gz"]
+	path = Tools/simulation/gz
+	url = https://github.com/CatScanners/PX4-gazebo-models.git


### PR DESCRIPTION
Fixing the bug added in https://github.com/CatScanners/PX4-Autopilot/pull/1.

Tested by @kobezu.